### PR TITLE
Introduce `queryWith`

### DIFF
--- a/src/Data/FileCache.hs
+++ b/src/Data/FileCache.hs
@@ -9,6 +9,6 @@ This is usually done in the following fashion :
 
 The computation will be used to populate the cache if this call results in a miss. The result is forced to WHNM.
 -}
-module Data.FileCache (FileCache, FileCacheR, newFileCache, killFileCache, invalidate, query, getCache, lazyQuery) where
+module Data.FileCache (FileCache, FileCacheR, newFileCache, killFileCache, invalidate, query, OnModified, queryWith, getCache, lazyQuery) where
 
 import Data.FileCache.Internal


### PR DESCRIPTION
This allows to install an additional hook to be installed, so that you can execute some arbitrary action whenever the files that you are watching are modified.

The diff as shown by GitHub is a little messy, but the changes are minimal: we record an optional `OnModified` hook in the `_cache`; `query` is now a thin wrapper around the more general `queryWith`, which just ensures that the hook passed gets added to the cache, and the event processing loop in `newFileCache` is modified to execute the hook whenever we remove an entry from the cache.